### PR TITLE
Repaired RST errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ FixtureManager()
 Class for setting up a set of fixtures on. This should be inherited from into another class with its own set of fixtures.
 
 .. code:: python
+
     class FakeElasticsearch(httpretty_fixtures.FixtureManager):
         @httpretty_fixtures.get('http://localhost:9200/my_index/my_document/my_id')
         def es_index(self, request, uri, res_headers):
@@ -90,6 +91,7 @@ Decorator to run a set of fixtures during a function
   - \* ``str`` - Name of fixtures function to run
 
 .. code:: python
+
     class FakeElasticsearch(httpretty_fixtures.FixtureManager):
         @httpretty_fixtures.get('http://localhost:9200/my_index/my_document/my_id')
         def es_index(self, request, uri, res_headers):


### PR DESCRIPTION
It appears my drunken self forgot to properly space some of our code blocks in our README which broke PyPI's parser. After running `restructuredtext-lint`, we have found/patched the errors. In this PR:
- Fix up spacing in README.rst to satisfy the PyPI gods

/cc @brettlangdon 
