### PR TITLE
Added per-fixture request information

### DIFF
--- a/docs/examples_preserve_state.py
+++ b/docs/examples_preserve_state.py
@@ -20,7 +20,7 @@ class CounterServer(httpretty_fixtures.FixtureManager):
 # Define our tests
 class MyTestCase(unittest.TestCase):
     @CounterServer.run(['counter'])
-    def test_counter_state(self):
+    def test_counter_state(self, counter_server):
         """Verify we can preserve state between requests"""
         # Make our first request and verify its count
         res = requests.get('http://localhost:9000/')
@@ -33,7 +33,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(res.text, '2')
 
     @CounterServer.run(['counter'])
-    def test_counter_alternate_state(self):
+    def test_counter_alternate_state(self, counter_server):
         """Verify state is not maintained between separate `FixtureManager.run()'s`"""
         res = requests.get('http://localhost:9000/')
         self.assertEqual(res.status_code, 200)

--- a/httpretty_fixtures/test/test.py
+++ b/httpretty_fixtures/test/test.py
@@ -27,10 +27,11 @@ class CounterServer(httpretty_fixtures.FixtureManager):
 # Define our tests
 class TestHttprettyFixtures(TestCase):
     @FakeServer.run(['hello'])
-    def test_request(self):
+    def test_request(self, fake_server):
         """
         A request to a non-existant server behind a running FixtureManager
             receives a response from FixtureManager
+            collects the request for later access
         """
         # Make our request
         res = requests.get('http://localhost:9000/')
@@ -39,17 +40,24 @@ class TestHttprettyFixtures(TestCase):
         # Assert the content is as expected
         self.assertEqual(res.text, 'world')
 
-        # Assert we have information in our requests
+        # Assert we have information in our requests from `httpretty` context
         self.assertEqual(httpretty_fixtures.first_request().path, '/')
         self.assertEqual(httpretty_fixtures.last_request().path, '/')
         self.assertEqual(len(httpretty_fixtures.requests()), 1)
         self.assertEqual(httpretty_fixtures.requests()[0].path, '/')
 
+        # Assert we have information in our requests from fixture context
+        fixture = fake_server.hello
+        self.assertEqual(fixture.first_request.path, '/')
+        self.assertEqual(fixture.last_request.path, '/')
+        self.assertEqual(len(fixture.requests), 1)
+        self.assertEqual(fixture.requests[0].path, '/')
+
     @FakeServer.run(['hello'])
-    def test_multiple_requests(self):
+    def test_multiple_requests(self, fake_server):
         """
         Multiple requests to a running FixtureManager
-            separates requests
+            collects separate requests
         """
         # Make our request
         res = requests.get('http://localhost:9000/?first')
@@ -57,15 +65,23 @@ class TestHttprettyFixtures(TestCase):
         res = requests.get('http://localhost:9000/?second')
         self.assertEqual(res.status_code, 200)
 
-        # Assert we have information in our requests
+        # Assert we have information in our requests from `httpretty` context
         self.assertEqual(httpretty_fixtures.first_request().path, '/?first')
         self.assertEqual(httpretty_fixtures.last_request().path, '/?second')
         self.assertEqual(len(httpretty_fixtures.requests()), 2)
         self.assertEqual(httpretty_fixtures.requests()[0].path, '/?first')
         self.assertEqual(httpretty_fixtures.requests()[1].path, '/?second')
 
+        # Assert we have information in our requests from fixture context
+        fixture = fake_server.hello
+        self.assertEqual(fixture.first_request.path, '/?first')
+        self.assertEqual(fixture.last_request.path, '/?second')
+        self.assertEqual(len(fixture.requests), 2)
+        self.assertEqual(fixture.requests[0].path, '/?first')
+        self.assertEqual(fixture.requests[1].path, '/?second')
+
     @CounterServer.run(['counter'])
-    def test_state_preserved(self):
+    def test_state_preserved(self, counter_server):
         """
         Multiple stateful requests to a running FixtureManager
             receive appropriate state
@@ -81,7 +97,7 @@ class TestHttprettyFixtures(TestCase):
         self.assertEqual(res.text, '2')
 
     @CounterServer.run(['counter'])
-    def test_state_disjoint(self):
+    def test_state_disjoint(self, counter_server):
         """
         A separately running FixtureManager
             does not receive state from past runs


### PR DESCRIPTION
As discussed in #1, we would like to access per-fixture request information. This PR adds support for that. In this PR:
- Updated decorator signature to always pass in generated server from `.run`/`.start`
- Added tests
- Added support for per-fixture request information
- Added documentation

**Notes:**

This is a breaking change as all decorators must accept the new server as a parameter. We cannot leverage a `self` property as that would prevent accessing a single server if someone runs multiple ones (e.g. `fake_google` and `fake_elasticsearch` cannot both be accessed via `self.server`).

I have decided to leave out `call_count` and `called` which we had on `spy-server`. I felt those were redundant and not used too often in our context.

/cc @brettlangdon 
