### PR TITLE
Keep nested_count on FixtureManager

### DIFF
--- a/httpretty_fixtures/__init__.py
+++ b/httpretty_fixtures/__init__.py
@@ -97,7 +97,8 @@ class FixtureManager(object):
                             'Please make it a list or a tuple.')
 
         # Increase our internal counter
-        cls.nested_count += 1
+        # DEV: Keep count on our base class so the `nested_count` is "global" for all subclasses
+        FixtureManager.nested_count += 1
 
         # If HTTPretty hasn't been started yet, then reset its info and start it
         if not HTTPretty.is_enabled():
@@ -150,15 +151,15 @@ class FixtureManager(object):
     def stop(cls):
         """Stop running this class' fixtures"""
         # Decrease our counter
-        cls.nested_count -= 1
+        FixtureManager.nested_count -= 1
 
         # If we have stopped running too many times, complain and leave
-        if cls.nested_count < 0:
+        if FixtureManager.nested_count < 0:
             raise RuntimeError('When running `httpretty-fixtures`, `stop()`'
                                'was run more times than (or before) `start()`')
 
         # If we have gotten out of nesting, then stop HTTPretty and
-        if cls.nested_count == 0:
+        if FixtureManager.nested_count == 0:
             HTTPretty.disable()
 
 


### PR DESCRIPTION
We had a small bug where we were manually using a `FixtureManager` inside of a test case, as opposed to as a decorator, when we noticed that the decorated fixtures were being stopped.

Here is a small example to illustrate how we caused the issue:

``` python
@contextlib.contextmanager
def service_one_manager(fixtures):
    ServiceOneManager.start(fixtures)
    yield
    ServiceOneManager.stop()


@ServiceTwoManager.run(['service_two_fixture'])
def test_case(service_two):
    with service_one_manager(['service_one_fixture']):
        # Do some setup thing
        pass

    # This will succeed
    self.assertEqual(httpretty.is_enabled(), False)

    # This will fail
    call_service_two_fixture()
```

The fix here is to attach our `nested_count` counter directly to the base `FixtureManager` class instead of binding it to `cls`. This causes us to have a "global" count rathe than one for each subclass of `FixtureManager`.

/cc @underdogio/engineering 
