### PR TITLE
Do not disable HTTPretty if enabled outside FixtureManager

### DIFF
--- a/httpretty_fixtures/__init__.py
+++ b/httpretty_fixtures/__init__.py
@@ -8,6 +8,8 @@ from httpretty import HTTPretty
 class FixtureManager(object):
     # Store a count for HTTPretty across all classes
     nested_count = 0
+    # Whether or not we should disable HTTPretty when all FixtureManagers are stopped
+    httpretty_enabled_at_start = False
 
     @classmethod
     def generate_saving_fixture(cls, fixture):
@@ -96,6 +98,11 @@ class FixtureManager(object):
             raise TypeError('Expected `fixtures` to be an iterable sequence but it was not. '
                             'Please make it a list or a tuple.')
 
+        # Keep track if HTTPretty was started outside of FixtureManager
+        #   This means that we should not auto-disable HTTPretty when nested_count returns to 0
+        if FixtureManager.nested_count == 0:
+            FixtureManager.httpretty_enabled_at_start = HTTPretty.is_enabled()
+
         # Increase our internal counter
         # DEV: Keep count on our base class so the `nested_count` is "global" for all subclasses
         FixtureManager.nested_count += 1
@@ -159,7 +166,8 @@ class FixtureManager(object):
                                'was run more times than (or before) `start()`')
 
         # If we have gotten out of nesting, then stop HTTPretty and
-        if FixtureManager.nested_count == 0:
+        # DEV: Only disable HTTPretty if it was started outside of FixtureManager
+        if FixtureManager.nested_count == 0 and not FixtureManager.httpretty_enabled_at_start:
             HTTPretty.disable()
 
 

--- a/httpretty_fixtures/test/test.py
+++ b/httpretty_fixtures/test/test.py
@@ -174,3 +174,26 @@ class TestHttprettyFixtures(TestCase):
 
         # We finally stop HTTPretty since the last fixture manager is stopped
         self.assertFalse(httpretty.is_enabled())
+
+    def test_httpretty_enabled_outside_fixture_manager(self):
+        """
+        When HTTPretty was started outside of FixtureManager
+            we do not disable HTTPretty when the last FixtureManager is stopped
+        """
+        # Start HTTPretty manually
+        httpretty.enable()
+        self.assertEqual(httpretty.is_enabled(), True)
+
+        # Start one of our FixtureManagers
+        FakeServer.start(['hello'])
+        self.assertEqual(FakeServer.httpretty_enabled_at_start, True)
+        self.assertEqual(httpretty.is_enabled(), True)
+
+        # Stop out FixtureManger and ensure HTTPretty is still running
+        FakeServer.stop()
+        self.assertEqual(FakeServer.nested_count, 0)
+        self.assertEqual(httpretty.is_enabled(), True)
+
+        # Disable HTTPretty manually and ensure it is stopped
+        httpretty.disable()
+        self.assertEqual(httpretty.is_enabled(), False)


### PR DESCRIPTION
From suggestion from @twolfson in #7 there was another edge case we were not accounting for when disabling `HTTPretty`.

If we enabled `HTTPretty` manually outside of `FixtureManager`, then we would still disable it when our `nested_count` reaches 0.

In this PR we are adding in a new class attribute `disable_when_done` which will keep track of whether `HTTPretty` is enabled or not when starting the first `FixtureManager`. We can then use this to know if we should disable `HTTPretty` when our `nested_count` is decremented back down to 0.
